### PR TITLE
feat: add configurable human delay jitter before upstream requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,8 @@ credentials are documented in [Account setup](#account-setup).
 | `DANYAPI_LOG_FILE` | (empty) | File path for persistent logs; empty = console only |
 | `DANYAPI_LOG_MAX_BYTES` | `10485760` | Max log file size in bytes before rotation |
 | `DANYAPI_LOG_BACKUP_COUNT` | `3` | Number of rotated log files to keep |
+| `DANYAPI_HUMAN_DELAY_MIN` | `0.5` | Minimum delay in seconds before sending a request (uniform random jitter) |
+| `DANYAPI_HUMAN_DELAY_MAX` | `3.0` | Maximum delay in seconds; set both to `0` to disable |
 
 ## Usage
 

--- a/danyapi/api/openai.py
+++ b/danyapi/api/openai.py
@@ -4,6 +4,7 @@ import asyncio
 import base64
 import json
 import logging
+import random
 import sys
 import time
 import uuid
@@ -400,6 +401,13 @@ RETRY_BACKOFF_MAX_SEC = 8.0
 DEEPSEEK_AUTH_ERROR_CODES = {40001, 40002, 40003, 40012, 40029}
 
 
+async def _human_delay() -> None:
+    """Simulate human typing / pause before sending a message."""
+    delay = random.uniform(settings.human_delay_min, settings.human_delay_max)
+    if delay > 0:
+        await asyncio.sleep(delay)
+
+
 def _resolve_provider(model: str) -> str:
     if model.startswith("qwen"):
         return "qwen"
@@ -719,6 +727,7 @@ async def _collect_non_stream(
     include_usage=False,
     context_seq: tuple[str, ...] | None = None,
 ):
+    await _human_delay()
     async with lock:
         session, session_key, parent_message_id = await _prepare_session(account, pool, existing_sid, context_seq)
         stop_message_id: str | None = None
@@ -851,6 +860,7 @@ async def _stream_openai(
     def sse(data: dict) -> str:
         return f"data: {json.dumps(data, ensure_ascii=False)}\n\n"
 
+    await _human_delay()
     async with lock:
         try:
             session, session_key, parent_message_id = await _prepare_session(account, pool, existing_sid, context_seq)

--- a/danyapi/config.py
+++ b/danyapi/config.py
@@ -69,6 +69,14 @@ class Settings:
             self.log_backup_count = 3
         self.cache_dir = os.environ.get("DANYAPI_CACHE_DIR", "").strip()
         self.cache_enabled = os.environ.get("DANYAPI_CACHE_DISABLED", "").strip().lower() not in ("1", "true", "yes", "on")
+        try:
+            self.human_delay_min = float(os.environ.get("DANYAPI_HUMAN_DELAY_MIN", "0.5"))
+        except ValueError:
+            self.human_delay_min = 0.5
+        try:
+            self.human_delay_max = float(os.environ.get("DANYAPI_HUMAN_DELAY_MAX", "3.0"))
+        except ValueError:
+            self.human_delay_max = 3.0
 
 
 settings = Settings()

--- a/danyapi/qwen/api.py
+++ b/danyapi/qwen/api.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+import random
 import sys
 import time
 import uuid
@@ -11,6 +12,7 @@ import httpx
 from fastapi import HTTPException
 
 from .. import tools as toolemu
+from ..config import settings
 from ..deepseek.stream import IncrementalSSE
 from .client import QwenClient, QwenError
 from .stream import QwenStreamReconstructor, error_code
@@ -183,6 +185,13 @@ async def _try_stop_stream(client, session_id: str, message_id: str | None) -> N
         log.debug("stop_stream failed for %s: %s", session_id, exc)
 
 
+async def _human_delay() -> None:
+    """Simulate human typing / pause before sending a message."""
+    delay = random.uniform(settings.human_delay_min, settings.human_delay_max)
+    if delay > 0:
+        await asyncio.sleep(delay)
+
+
 def _accumulate_usage(session, rec: QwenStreamReconstructor) -> dict:
     current = rec.usage_tokens
     prev_input = int(getattr(session, "accumulated_input_tokens", 0) or 0)
@@ -213,6 +222,7 @@ async def collect_non_stream(
     include_usage=False,
     context_seq: tuple[str, ...] | None = None,
 ):
+    await _human_delay()
     async with lock:
         session, session_key = await _prepare_session(account, pool, existing_sid, model_id, context_seq)
         stop_response_id: str | None = None
@@ -319,6 +329,7 @@ async def stream_openai(
     def sse(data: dict) -> str:
         return f"data: {json.dumps(data, ensure_ascii=False)}\n\n"
 
+    await _human_delay()
     async with lock:
         try:
             session, session_key = await _prepare_session(account, pool, existing_sid, model_id, context_seq)


### PR DESCRIPTION
## Problem

When using multiple accounts through DanyAPI, requests fire immediately as soon as an account slot is free. This produces a bursty, machine-like pattern that can be detected by upstream providers (DeepSeek / Qwen) as unsanctioned usage.

## Solution

Add \`DANYAPI_HUMAN_DELAY_MIN\` and \`DANYAPI_HUMAN_DELAY_MAX\` environment variables to introduce a random delay (uniform distribution) between acquiring an account from the pool and sending the completion request. This simulates human typing/pause behavior before hitting "Send".

- **Default:** 0.5–3.0 seconds
- **Disable:** set both to \`0\`
- Applies to all 4 paths: DeepSeek + Qwen × stream / non-stream

## Changes

- \`danyapi/config.py\` — new \`human_delay_min\` / \`human_delay_max\` settings
- \`danyapi/api/openai.py\` — \`_human_delay()\` in \`_collect_non_stream\` and \`_stream_openai\` (DeepSeek)
- \`danyapi/qwen/api.py\` — \`_human_delay()\` in \`collect_non_stream\` and \`stream_openai\` (Qwen)
- \`README.md\` — documented the new variables

## Config

| Variable | Default | Description |
| --- | --- | --- |
| \`DANYAPI_HUMAN_DELAY_MIN\` | \`0.5\` | Min delay in seconds before sending a request |
| \`DANYAPI_HUMAN_DELAY_MAX\` | \`3.0\` | Max delay; set both to \`0\` to disable |

Backward compatible — no behavior change for existing deployments except the small default jitter.