### PR TITLE
feat: OpenAI-compat hardening (reasoning_effort, tool-result truncation, XML coercion, json_schema validation)

### DIFF
--- a/danyapi/api/openai.py
+++ b/danyapi/api/openai.py
@@ -92,6 +92,7 @@ class ChatCompletionRequest(BaseModel):
     temperature: float | None = None
     top_p: float | None = None
     thinking: bool | None = None
+    reasoning_effort: str | None = None
     search: bool | None = None
     session_id: str | None = None
     user: str | None = None
@@ -101,6 +102,20 @@ class ChatCompletionRequest(BaseModel):
     parallel_tool_calls: bool | None = None
     response_format: Any = None
     stream_options: Any = None
+
+
+def _resolve_thinking(req: ChatCompletionRequest, default: bool) -> bool:
+    """Resolve the thinking flag from either 'thinking' or 'reasoning_effort'.
+
+    OpenAI-compatible clients (e.g. Kimi Code) send reasoning_effort ("low"/"medium"/"high").
+    Map any non-none value to True so DanyAPI enables thinking on the upstream provider.
+    """
+    if req.thinking is not None:
+        return bool(req.thinking)
+    effort = (req.reasoning_effort or "").strip().lower()
+    if effort and effort != "off" and effort != "none":
+        return True
+    return default
 
 
 @asynccontextmanager
@@ -483,7 +498,7 @@ async def _chat_completions_deepseek(req: ChatCompletionRequest) -> Any:
         raise HTTPException(503, "deepseek provider is not configured")
 
     model_type = _resolve_model(req.model)
-    thinking = req.thinking if req.thinking is not None else (model_type == "expert")
+    thinking = _resolve_thinking(req, default=(model_type == "expert"))
     search = bool(req.search) and model_type == "default"
 
     context_seq = toolemu.context_sequence(req.messages, user=getattr(req, "user", None))
@@ -500,9 +515,11 @@ async def _chat_completions_deepseek(req: ChatCompletionRequest) -> Any:
             getattr(req, "tool_choice", None),
             existing_sid is not None,
             getattr(req, "response_format", None),
+            tool_result_limit=settings.tool_result_max_chars,
         )
     except ValueError as exc:
         raise HTTPException(400, str(exc)) from exc
+    json_schema = toolemu.response_format_schema(getattr(req, "response_format", None))
 
     attachments = _collect_attachments(req)
     _validate_attachments(attachments, model_type)
@@ -524,6 +541,7 @@ async def _chat_completions_deepseek(req: ChatCompletionRequest) -> Any:
         "tool_mode": tool_mode,
         "include_usage": _include_usage(req),
         "context_seq": context_seq,
+        "json_schema": json_schema,
     }
     if req.stream:
         return StreamingResponse(
@@ -543,7 +561,7 @@ async def _chat_completions_qwen(req: ChatCompletionRequest) -> Any:
     if pool is None:
         raise HTTPException(503, "qwen provider is not configured")
 
-    thinking = req.thinking if req.thinking is not None else True
+    thinking = _resolve_thinking(req, default=True)
     search = bool(req.search)
 
     context_seq = toolemu.context_sequence(req.messages, user=getattr(req, "user", None))
@@ -560,9 +578,11 @@ async def _chat_completions_qwen(req: ChatCompletionRequest) -> Any:
             getattr(req, "tool_choice", None),
             existing_sid is not None,
             getattr(req, "response_format", None),
+            tool_result_limit=settings.tool_result_max_chars,
         )
     except ValueError as exc:
         raise HTTPException(400, str(exc)) from exc
+    json_schema = toolemu.response_format_schema(getattr(req, "response_format", None))
 
     common = {
         "account": account,
@@ -577,6 +597,7 @@ async def _chat_completions_qwen(req: ChatCompletionRequest) -> Any:
         "tool_mode": tool_mode,
         "include_usage": _include_usage(req),
         "context_seq": context_seq,
+        "json_schema": json_schema,
     }
     if req.stream:
         return StreamingResponse(
@@ -843,6 +864,7 @@ async def _collect_non_stream(
     tool_schemas=None,
     include_usage=False,
     context_seq: tuple[str, ...] | None = None,
+    json_schema: dict | None = None,
 ):
     await _human_delay()
     async with account_lock(lock, settings.acquire_timeout):
@@ -953,6 +975,17 @@ async def _collect_non_stream(
             message = {"role": "assistant", "content": content}
             if reasoning:
                 message["reasoning_content"] = reasoning
+            # Validate JSON response against schema if present
+            if json_schema is not None and content.strip():
+                try:
+                    parsed_content = json.loads(content)
+                    toolemu.validate_json_response(parsed_content, json_schema)
+                except json.JSONDecodeError as exc:
+                    log.warning("JSON mode: invalid JSON response: %s", exc)
+                    raise HTTPException(400, f"Invalid JSON response: {exc}") from None
+                except ValueError as exc:
+                    log.warning("JSON mode: schema validation failed: %s", exc)
+                    raise HTTPException(400, str(exc)) from None
         return {
             "id": f"chatcmpl-{uuid.uuid4().hex}",
             "object": "chat.completion",
@@ -985,6 +1018,7 @@ async def _stream_openai(
     tool_schemas=None,
     include_usage=False,
     context_seq: tuple[str, ...] | None = None,
+    json_schema: dict | None = None,
 ):
     chunk_id = f"chatcmpl-{uuid.uuid4().hex}"
     created = int(time.time())
@@ -1112,9 +1146,8 @@ async def _stream_openai(
                             )
                         delta: dict = {}
                         if c_diff:
-                            if tool_mode:
-                                content_buf += c_diff
-                            else:
+                            content_buf += c_diff
+                            if not tool_mode:
                                 delta["content"] = c_diff
                         if r_diff:
                             delta["reasoning_content"] = r_diff
@@ -1199,9 +1232,8 @@ async def _stream_openai(
                 rec.extend_with(cont_rec)
                 cont_parent = cont_rec.id or cont_parent
                 if cont_rec.content:
-                    if tool_mode:
-                        content_buf += cont_rec.content
-                    else:
+                    content_buf += cont_rec.content
+                    if not tool_mode:
                         yield sse(
                             {
                                 "id": chunk_id,
@@ -1293,6 +1325,55 @@ async def _stream_openai(
                     )
                 finish = _finish_reason(rec.status)
         else:
+            # Validate JSON response against schema if present
+            if json_schema is not None and content_buf.strip():
+                try:
+                    parsed_content = json.loads(content_buf)
+                    toolemu.validate_json_response(parsed_content, json_schema)
+                except json.JSONDecodeError as exc:
+                    log.warning("JSON mode: invalid JSON response: %s", exc)
+                    yield sse(
+                        {
+                            "id": chunk_id,
+                            "object": "chat.completion.chunk",
+                            "created": created,
+                            "model": model,
+                            "error": {"message": f"Invalid JSON response: {exc}"},
+                            "choices": [{"index": 0, "delta": {}, "finish_reason": "error"}],
+                        }
+                    )
+                    yield sse(
+                        {
+                            "id": chunk_id,
+                            "session_id": session_key,
+                            "object": "chat.completion.chunk",
+                            "choices": [],
+                        }
+                    )
+                    yield "data: [DONE]\n\n"
+                    return
+                except ValueError as exc:
+                    log.warning("JSON mode: schema validation failed: %s", exc)
+                    yield sse(
+                        {
+                            "id": chunk_id,
+                            "object": "chat.completion.chunk",
+                            "created": created,
+                            "model": model,
+                            "error": {"message": str(exc)},
+                            "choices": [{"index": 0, "delta": {}, "finish_reason": "error"}],
+                        }
+                    )
+                    yield sse(
+                        {
+                            "id": chunk_id,
+                            "session_id": session_key,
+                            "object": "chat.completion.chunk",
+                            "choices": [],
+                        }
+                    )
+                    yield "data: [DONE]\n\n"
+                    return
             finish = _finish_reason(rec.status)
 
         yield sse(

--- a/danyapi/config.py
+++ b/danyapi/config.py
@@ -77,6 +77,10 @@ class Settings:
             self.human_delay_max = float(os.environ.get("DANYAPI_HUMAN_DELAY_MAX", "3.0"))
         except ValueError:
             self.human_delay_max = 3.0
+        try:
+            self.tool_result_max_chars = int(os.environ.get("DANYAPI_TOOL_RESULT_MAX_CHARS", "8000"))
+        except ValueError:
+            self.tool_result_max_chars = 8000
 
 
 settings = Settings()

--- a/danyapi/qwen/api.py
+++ b/danyapi/qwen/api.py
@@ -222,6 +222,7 @@ async def collect_non_stream(
     tool_schemas=None,
     include_usage=False,
     context_seq: tuple[str, ...] | None = None,
+    json_schema: dict | None = None,
 ):
     await _human_delay()
     async with account_lock(lock, settings.acquire_timeout):
@@ -297,6 +298,17 @@ async def collect_non_stream(
             message = {"role": "assistant", "content": rec.content}
             if rec.reasoning:
                 message["reasoning_content"] = rec.reasoning
+            # Validate JSON response against schema if present
+            if json_schema is not None and (rec.content or "").strip():
+                try:
+                    parsed_content = json.loads(rec.content)
+                    toolemu.validate_json_response(parsed_content, json_schema)
+                except json.JSONDecodeError as exc:
+                    log.warning("JSON mode: invalid JSON response: %s", exc)
+                    raise HTTPException(400, f"Invalid JSON response: {exc}") from None
+                except ValueError as exc:
+                    log.warning("JSON mode: schema validation failed: %s", exc)
+                    raise HTTPException(400, str(exc)) from None
             finish = "stop"
         return {
             "id": f"chatcmpl-{uuid.uuid4().hex}",
@@ -323,6 +335,7 @@ async def stream_openai(
     tool_schemas=None,
     include_usage=False,
     context_seq: tuple[str, ...] | None = None,
+    json_schema: dict | None = None,
 ):
     chunk_id = f"chatcmpl-{uuid.uuid4().hex}"
     created = int(time.time())
@@ -457,9 +470,8 @@ async def stream_openai(
                             )
                         delta: dict = {}
                         if c_diff:
-                            if tool_mode:
-                                content_buf += c_diff
-                            else:
+                            content_buf += c_diff
+                            if not tool_mode:
                                 delta["content"] = c_diff
                         if r_diff:
                             delta["reasoning_content"] = r_diff
@@ -605,6 +617,55 @@ async def stream_openai(
                     )
                 finish = "stop"
         else:
+            # Validate JSON response against schema if present
+            if json_schema is not None and content_buf.strip():
+                try:
+                    parsed_content = json.loads(content_buf)
+                    toolemu.validate_json_response(parsed_content, json_schema)
+                except json.JSONDecodeError as exc:
+                    log.warning("JSON mode: invalid JSON response: %s", exc)
+                    yield sse(
+                        {
+                            "id": chunk_id,
+                            "object": "chat.completion.chunk",
+                            "created": created,
+                            "model": model,
+                            "error": {"message": f"Invalid JSON response: {exc}"},
+                            "choices": [{"index": 0, "delta": {}, "finish_reason": "error"}],
+                        }
+                    )
+                    yield sse(
+                        {
+                            "id": chunk_id,
+                            "session_id": session_key,
+                            "object": "chat.completion.chunk",
+                            "choices": [],
+                        }
+                    )
+                    yield "data: [DONE]\n\n"
+                    return
+                except ValueError as exc:
+                    log.warning("JSON mode: schema validation failed: %s", exc)
+                    yield sse(
+                        {
+                            "id": chunk_id,
+                            "object": "chat.completion.chunk",
+                            "created": created,
+                            "model": model,
+                            "error": {"message": str(exc)},
+                            "choices": [{"index": 0, "delta": {}, "finish_reason": "error"}],
+                        }
+                    )
+                    yield sse(
+                        {
+                            "id": chunk_id,
+                            "session_id": session_key,
+                            "object": "chat.completion.chunk",
+                            "choices": [],
+                        }
+                    )
+                    yield "data: [DONE]\n\n"
+                    return
             finish = "stop"
 
         yield sse(

--- a/danyapi/tools.py
+++ b/danyapi/tools.py
@@ -8,6 +8,8 @@ from collections.abc import Iterator
 from dataclasses import dataclass
 from typing import Any
 
+import jsonschema
+
 _DSML_TAG = re.compile(
     r"<\s*/?\s*(?:\||\uff5c){2}\s*DSML\s*(?:\||\uff5c){2}[^>]*>"
     r"|(?:\||\uff5c){2}\s*DSML\s*(?:\||\uff5c){2}",
@@ -29,7 +31,9 @@ TOOL_CALL_INSTRUCTION = (
     '{{"tool_calls": [{{"name": "get_weather", "arguments": {{"city": "Moscow"}}}}]}}\n\n'
     "Use the exact function names and JSON argument keys from the definitions above. "
     'The value of "arguments" must be a JSON object with only those keys. '
-    'You may include multiple entries in the "tool_calls" array to call several functions at once.\n'
+    'You may include multiple entries in the "tool_calls" array to call several functions at once. '
+    "Large tool results are truncated to fit the context window, so keep tool inputs "
+    "(file line ranges, output sizes) as small as practical.\n"
     "{choice}"
 )
 
@@ -37,6 +41,19 @@ CHOICE_INSTRUCTIONS = {
     "required": "You MUST call one or more functions from the list above.",
     "function": "You MUST call exactly the function specified below and no other functions.",
 }
+
+# Default cap for a single tool result when rendering the upstream prompt.
+# A full file read (up to ~100 KB) would otherwise blow the upstream context.
+# 0 disables truncation.
+TOOL_RESULT_MAX_CHARS = 8000
+
+
+def _truncate_tool_result(text: str, limit: int) -> str:
+    if limit > 0 and len(text) > limit:
+        omitted = len(text) - limit
+        return f"{text[:limit]} ... [truncated: {omitted} more characters]"
+    return text
+
 
 JSON_MODE_INSTRUCTION = """You must reply with ONLY a valid JSON object, no markdown fences, no extra text, no explanations, no comments inside the JSON.
 {constraints}"""
@@ -187,7 +204,7 @@ def _render_tool_call_mention(call: Any) -> str:
     return f"[assistant called {name}({args})]"
 
 
-def render_message(msg: Any) -> str:
+def render_message(msg: Any, tool_result_limit: int = TOOL_RESULT_MAX_CHARS) -> str:
     role = getattr(msg, "role", "user")
     text = _content_text(getattr(msg, "content", ""))
     if role in ("user", "system"):
@@ -211,29 +228,29 @@ def render_message(msg: Any) -> str:
     if role == "tool":
         tool_call_id = getattr(msg, "tool_call_id", None) or ""
         prefix = f"Tool result ({tool_call_id})" if tool_call_id else "Tool result"
-        return f"{prefix}: {text}"
+        return f"{prefix}: {_truncate_tool_result(text, tool_result_limit)}"
     if role == "function":
         name = getattr(msg, "name", None) or ""
-        return f"Function {name} returned: {text}"
+        return f"Function {name} returned: {_truncate_tool_result(text, tool_result_limit)}"
     return text
 
 
-def _render_history(messages: list[Any]) -> str:
+def _render_history(messages: list[Any], tool_result_limit: int = TOOL_RESULT_MAX_CHARS) -> str:
     parts = []
     for msg in messages:
-        text = render_message(msg)
+        text = render_message(msg, tool_result_limit)
         if text:
             role = getattr(msg, "role", "user")
             parts.append(f"{role.capitalize()}: {text}")
     return "\n".join(parts)
 
 
-def _render_tool_tail(messages: list[Any]) -> str:
+def _render_tool_tail(messages: list[Any], tool_result_limit: int = TOOL_RESULT_MAX_CHARS) -> str:
     parts = []
     for msg in messages:
         role = getattr(msg, "role", None)
         if role in ("tool", "function"):
-            text = render_message(msg)
+            text = render_message(msg, tool_result_limit)
             if text:
                 parts.append(text)
     parts.append("Continue the conversation and provide the final answer based on the tool results.")
@@ -351,12 +368,42 @@ def render_json_mode(response_format: Any) -> str | None:
     return JSON_MODE_INSTRUCTION.format(constraints=constraints)
 
 
+def response_format_schema(response_format: Any) -> dict | None:
+    """The JSON Schema from a response_format of type "json_schema", if any.
+
+    Only a dict is returned: validation against a non-dict schema would raise
+    jsonschema.SchemaError, which the handlers do not catch.
+    """
+    if not isinstance(response_format, dict):
+        return None
+    if response_format.get("type") != "json_schema":
+        return None
+    raw = response_format.get("json_schema")
+    schema = raw.get("schema") if isinstance(raw, dict) else None
+    return schema if isinstance(schema, dict) else None
+
+
+def validate_json_response(response: Any, schema: dict | None) -> None:
+    """Validate a parsed JSON response against the schema.
+
+    Raises:
+        ValueError: If validation fails.
+    """
+    if schema is None:
+        return
+    try:
+        jsonschema.validate(instance=response, schema=schema)
+    except jsonschema.ValidationError as exc:
+        raise ValueError(f"Response does not match JSON schema: {exc.message}") from exc
+
+
 def build_prompt(
     messages: list[Any],
     tools: list[Any] | None = None,
     tool_choice: Any = None,
     has_session: bool = False,
     response_format: Any = None,
+    tool_result_limit: int = TOOL_RESULT_MAX_CHARS,
 ) -> tuple[str, bool]:
     schema = render_tool_schema(tools, tool_choice)
     tools_present = schema is not None
@@ -365,7 +412,7 @@ def build_prompt(
     if has_session:
         tail = _tail_after_last_user(messages)
         if _is_tool_round_tail(tail):
-            tail_prompt = _render_tool_tail(tail)
+            tail_prompt = _render_tool_tail(tail, tool_result_limit)
             return tail_prompt, True
         base = extract_last_user(messages)
         blocks = []
@@ -376,7 +423,7 @@ def build_prompt(
 
     tool_round_active = is_tool_round(messages)
     if tool_round_active or _has_history(messages):
-        prompt = _render_history(messages)
+        prompt = _render_history(messages, tool_result_limit)
         if schema:
             prompt = f"{schema}\n\n{prompt}"
         if json_block:
@@ -488,6 +535,26 @@ def _normalize_single_quotes(text: str) -> str:
     return "".join(out)
 
 
+_TOOL_CALLS_BAD_SEP = re.compile(r'"tool_calls"\s*([^\s":{\[\],\d\w-])')
+
+
+def _repair_tool_calls_key(text: str) -> str:
+    """Repair a corrupted separator after the `"tool_calls"` key.
+
+    Models occasionally emit e.g. `"tool_calls">` instead of `"tool_calls": [`,
+    dropping the colon and the opening bracket. Re-insert the colon, and the
+    opening bracket as well unless the value already starts with one, so that
+    a single object or a comma-separated list of objects parses as an array.
+    """
+
+    def _fix(match: re.Match) -> str:
+        if text[match.end() :].lstrip().startswith("["):
+            return '"tool_calls": '
+        return '"tool_calls": ['
+
+    return _TOOL_CALLS_BAD_SEP.sub(_fix, text)
+
+
 def _loads_lenient(text: str) -> Any:
     text = text.strip()
     try:
@@ -504,6 +571,16 @@ def _loads_lenient(text: str) -> Any:
             return json.loads(normalized)
         except (json.JSONDecodeError, TypeError, ValueError):
             pass
+    # Repair a corrupted "tool_calls" key separator (e.g. `"tool_calls">`)
+    repaired = _repair_tool_calls_key(text)
+    if repaired != text:
+        for candidate in (repaired, _strip_trailing_commas(repaired), _fix_unbalanced_json(repaired)):
+            if candidate is None:
+                continue
+            try:
+                return json.loads(candidate)
+            except (json.JSONDecodeError, TypeError, ValueError):
+                pass
     fixed = _fix_unbalanced_json(text)
     if fixed is not None and fixed != text:
         try:
@@ -673,9 +750,26 @@ def _unescape_xml(text: str) -> str:
     return text.replace("&lt;", "<").replace("&gt;", ">").replace("&quot;", '"').replace("&apos;", "'").replace("&amp;", "&")
 
 
+def _coerce_json_container(value: str) -> Any:
+    """Parse a JSON array/object embedded in a string parameter value.
+
+    DeepSeek emits nested structures as pre-serialized JSON strings; if the
+    value does not parse, or parses to a scalar, keep the raw string."""
+    stripped = value.strip()
+    if not stripped or stripped[0] not in "[{":
+        return value
+    try:
+        parsed = _loads_lenient(stripped)
+    except ValueError:
+        return value
+    return parsed if isinstance(parsed, (list, dict)) else value
+
+
 def _coerce_scalar(value: str, json_type: Any) -> Any:
     if not isinstance(value, str):
         return value
+    if json_type in ("array", "object"):
+        return _coerce_json_container(value)
     if json_type in ("integer", "number"):
         try:
             return int(value)
@@ -695,6 +789,62 @@ def _coerce_scalar(value: str, json_type: Any) -> Any:
     if json_type == "null":
         return None
     return value
+
+
+# Non-null types win: for union/nullable specs we coerce to the real value type,
+# not to None. "null" is the fallback for nullable-only properties. Containers
+# (array/object) rank above string: a failed JSON parse falls back to the raw
+# string, while a string hint would never attempt a parse.
+_TYPE_PRIORITY = ("integer", "number", "boolean", "array", "object", "string", "null")
+
+
+def _collect_declared_types(spec: dict) -> set[str]:
+    """All JSON types declared in a property spec, including types nested
+    inside anyOf/oneOf/allOf combinators (how union types are expressed)."""
+    types: set[str] = set()
+    typ = spec.get("type")
+    if isinstance(typ, str):
+        types.add(typ)
+    elif isinstance(typ, list):
+        types.update(t for t in typ if isinstance(t, str))
+    for combinator in ("anyOf", "oneOf", "allOf"):
+        variants = spec.get(combinator)
+        if not isinstance(variants, list):
+            continue
+        for variant in variants:
+            if isinstance(variant, dict):
+                types |= _collect_declared_types(variant)
+    return types
+
+
+def _coerce_untyped(value: str) -> Any:
+    """Coerce a parameter value whose type is unknown from the schema,
+    using JSON literal semantics. Non-literals are kept as strings."""
+    low = value.lower()
+    if low == "true":
+        return True
+    if low == "false":
+        return False
+    if low == "null":
+        return None
+    try:
+        return int(value)
+    except ValueError:
+        pass
+    try:
+        return float(value)
+    except ValueError:
+        pass
+    return _coerce_json_container(value)
+
+
+_STRING_ATTR_FALSE = re.compile(r'string\s*=\s*["\']?false["\']?', re.IGNORECASE)
+
+
+def _string_attr_is_false(attrs: str) -> bool:
+    """Whether a <parameter> tag carries the model's `string="false"` hint,
+    i.e. the value is a non-string JSON literal rather than text."""
+    return _STRING_ATTR_FALSE.search(attrs) is not None
 
 
 def tool_schema_map(tools: list[Any] | None) -> dict[str, dict[str, Any]]:
@@ -718,14 +868,12 @@ def tool_schema_map(tools: list[Any] | None) -> dict[str, dict[str, Any]]:
         for prop, spec in properties.items():
             if not isinstance(spec, dict):
                 continue
-            typ = spec.get("type")
-            if isinstance(typ, list):
-                for candidate in ("integer", "number", "boolean", "null", "string"):
-                    if candidate in typ:
-                        typ = candidate
+            declared = _collect_declared_types(spec)
+            if declared:
+                for candidate in _TYPE_PRIORITY:
+                    if candidate in declared:
+                        prop_types[prop] = candidate
                         break
-            if typ:
-                prop_types[prop] = typ
         if prop_types:
             result[name] = prop_types
     return result
@@ -733,16 +881,21 @@ def tool_schema_map(tools: list[Any] | None) -> dict[str, dict[str, Any]]:
 
 def _xml_invoke_arguments(body: str, param_types: dict[str, Any] | None = None) -> dict[str, Any] | None:
     stripped = body.strip()
-    if stripped.startswith("{"):
+    if stripped and stripped[0] in "{[":
         try:
             parsed = _loads_lenient(stripped)
-            if isinstance(parsed, dict):
+            if isinstance(parsed, (dict, list)):
                 return parsed
         except ValueError:
             pass
     params: dict[str, Any] = {}
-    for match in re.finditer(r'<parameter\s+name=["\']([^"\']+)["\']\s*>(.*?)</parameter>', body, re.DOTALL | re.IGNORECASE):
-        params[match.group(1).strip()] = _coerce_scalar(_unescape_xml(match.group(2).strip()), (param_types or {}).get(match.group(1).strip()))
+    for match in re.finditer(r'<parameter\s+name=["\']([^"\']+)["\']([^>]*)>(.*?)</parameter>', body, re.DOTALL | re.IGNORECASE):
+        name = match.group(1).strip()
+        value = _unescape_xml(match.group(3).strip())
+        type_hint = (param_types or {}).get(name)
+        if type_hint is None and _string_attr_is_false(match.group(2)):
+            value = _coerce_untyped(value)
+        params[name] = _coerce_scalar(value, type_hint)
     if params:
         return params
     has_children = False
@@ -754,7 +907,8 @@ def _xml_invoke_arguments(body: str, param_types: dict[str, Any] | None = None) 
     inner = _unescape_xml(body.strip())
     if inner:
         return {"content": inner}
-    return None
+    # Empty body = zero-argument call (e.g. EnterPlanMode) → {}, not "no call".
+    return {}
 
 
 def _xml_tag_attrs(body: str, param_types: dict[str, Any] | None = None) -> dict[str, Any]:

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ uvicorn[standard]>=0.52.1
 httpx>=0.28.1
 pydantic>=2.13.4
 python-dotenv>=1.2.2
+jsonschema>=4.20.0

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -78,6 +78,12 @@ def test_invalid_log_backup_falls_back(settings_for):
     assert settings_for({"DANYAPI_LOG_BACKUP_COUNT": "5"}).log_backup_count == 5
 
 
+def test_tool_result_max_chars(settings_for):
+    assert settings_for({}).tool_result_max_chars == 8000
+    assert settings_for({"DANYAPI_TOOL_RESULT_MAX_CHARS": "bad"}).tool_result_max_chars == 8000
+    assert settings_for({"DANYAPI_TOOL_RESULT_MAX_CHARS": "123"}).tool_result_max_chars == 123
+
+
 def test_deepseek_tokens_comma(settings_for):
     s = settings_for({"DEEPSEEK_TOKENS": "a, b , c"})
     assert s.deepseek_tokens == ["a", "b", "c"]

--- a/tests/test_retry.py
+++ b/tests/test_retry.py
@@ -348,6 +348,7 @@ async def test_search_gated_to_flash_and_thinking_allowed():
                 model=model,
                 stream=False,
                 thinking=thinking,
+                reasoning_effort=None,
                 search=search,
                 session_id=None,
                 files=None,

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -4,6 +4,7 @@ from typing import Any
 import pytest
 
 from danyapi.tools import (
+    TOOL_RESULT_MAX_CHARS,
     ToolCall,
     _coerce_scalar,
     _content_fingerprint,
@@ -31,8 +32,10 @@ from danyapi.tools import (
     render_json_mode,
     render_message,
     render_tool_schema,
+    response_format_schema,
     tool_call_deltas,
     tool_schema_map,
+    validate_json_response,
 )
 
 WEATHER_TOOL = {
@@ -44,6 +47,55 @@ WEATHER_TOOL = {
             "type": "object",
             "properties": {"city": {"type": "string"}},
             "required": ["city"],
+        },
+    },
+}
+
+# Mirrors the kimi-code Read tool: line_offset is a union of two integer
+# ranges, so its JSON Schema has no top-level "type" — only an anyOf.
+READ_TOOL = {
+    "type": "function",
+    "function": {
+        "name": "Read",
+        "description": "Read a text file",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "path": {"type": "string"},
+                "line_offset": {
+                    "anyOf": [
+                        {"type": "integer", "minimum": 1},
+                        {"type": "integer", "minimum": -1000, "maximum": -1},
+                    ]
+                },
+                "n_lines": {"type": "integer"},
+            },
+            "required": ["path"],
+        },
+    },
+}
+
+# Mirrors the kimi-code TodoList tool: a single array-typed property.
+TODO_TOOL = {
+    "type": "function",
+    "function": {
+        "name": "TodoList",
+        "description": "Update the todo list",
+        "parameters": {
+            "type": "object",
+            "properties": {
+                "todos": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "title": {"type": "string"},
+                            "status": {"type": "string", "enum": ["pending", "in_progress", "done"]},
+                        },
+                        "required": ["title", "status"],
+                    },
+                }
+            },
         },
     },
 }
@@ -552,6 +604,35 @@ def test_render_json_mode_schema():
     assert '"type": "object"' in block
 
 
+def test_response_format_schema_returns_schema():
+    schema = {"type": "object", "required": ["answer"], "properties": {"answer": {"type": "integer"}}}
+    rf = {"type": "json_schema", "json_schema": {"name": "answer", "schema": schema}}
+    assert response_format_schema(rf) is schema
+
+
+def test_response_format_schema_rejects_other_shapes():
+    assert response_format_schema(None) is None
+    assert response_format_schema("json_object") is None
+    assert response_format_schema({"type": "json_object"}) is None
+    assert response_format_schema({"type": "json_schema"}) is None
+    assert response_format_schema({"type": "json_schema", "json_schema": {"schema": 42}}) is None
+
+
+def test_validate_json_response_none_schema_is_noop():
+    validate_json_response({"anything": "goes"}, None)
+
+
+def test_validate_json_response_valid():
+    schema = {"type": "object", "required": ["answer"], "properties": {"answer": {"type": "integer"}}}
+    validate_json_response({"answer": 42}, schema)
+
+
+def test_validate_json_response_invalid():
+    schema = {"type": "object", "required": ["answer"], "properties": {"answer": {"type": "integer"}}}
+    with pytest.raises(ValueError, match="does not match JSON schema"):
+        validate_json_response({"answer": "not a number"}, schema)
+
+
 def test_extract_system_collects_system():
     messages = [
         Message(role="system", content="one"),
@@ -862,7 +943,8 @@ def test_xml_invoke_inline_json():
 
     args = _xml_invoke_arguments('{"cmd": "ls"}')
     assert args == {"cmd": "ls"}
-    assert _xml_invoke_arguments("  ") is None
+    # Empty body = zero-argument call → {}, not "no call".
+    assert _xml_invoke_arguments("  ") == {}
 
 
 def test_xml_tag_attrs():
@@ -981,10 +1063,15 @@ def test_parse_two_objects_second_is_tool_call():
     assert calls[0].name == "f"
 
 
-def test_xml_invoke_empty_args_skipped():
+def test_xml_invoke_empty_args_zero_arg_call():
+    # Empty invoke body = zero-argument call → "{}", not a skipped call.
     text = '<tool_calls><invoke name="bash">   </invoke></tool_calls>'
     parsed = _parse_xml_tool_calls(text, {"bash": {"cmd": "string"}})
-    assert parsed == (None, "")
+    assert parsed is not None
+    calls, _ = parsed
+    assert calls is not None
+    assert [c.name for c in calls] == ["bash"]
+    assert calls[0].arguments == "{}"
 
 
 def test_xml_open_pattern_overlap_skipped():
@@ -1073,3 +1160,287 @@ def test_iter_json_objects_skips_bad_candidates():
     text = '{"ok": 1} not-json {"bad": broken}'
     objs = [obj for obj, _, _ in _iter_json_objects(text)]
     assert objs == [{"ok": 1}]
+
+
+def _tool_result_msg(text: str) -> Message:
+    return Message(role="tool", content=text, tool_call_id="call_1")
+
+
+def test_tool_result_short_untouched():
+    assert render_message(_tool_result_msg("42")) == "Tool result (call_1): 42"
+
+
+def test_tool_result_long_truncated():
+    long_text = "x" * 20000
+    out = render_message(_tool_result_msg(long_text))
+    assert out.startswith("Tool result (call_1): " + "x" * TOOL_RESULT_MAX_CHARS)
+    assert f"[truncated: {20000 - TOOL_RESULT_MAX_CHARS} more characters]" in out
+    assert len(out) < len(long_text)
+
+
+def test_tool_result_custom_limit():
+    out = render_message(_tool_result_msg("y" * 100), tool_result_limit=40)
+    assert out.endswith("y" * 40 + " ... [truncated: 60 more characters]")
+
+
+def test_tool_result_limit_zero_disables():
+    long_text = "z" * 500
+    assert render_message(_tool_result_msg(long_text), tool_result_limit=0) == f"Tool result (call_1): {long_text}"
+
+
+def test_function_result_truncated():
+    msg = Message(role="function", content="f" * 9000, name="get_weather")
+    assert "[truncated:" in render_message(msg)
+
+
+def test_build_prompt_session_tail_truncates_tool_result():
+    messages = [
+        Message(role="user", content="read the file"),
+        Message(role="assistant", tool_calls=[{"id": "c1", "type": "function", "function": {"name": "Read", "arguments": "{}"}}]),
+        Message(role="tool", content="r" * 20000, tool_call_id="c1"),
+    ]
+    prompt, tool_mode = build_prompt(messages, None, None, has_session=True)
+    assert tool_mode
+    assert "[truncated:" in prompt
+    assert len(prompt) < TOOL_RESULT_MAX_CHARS + 500
+
+
+def test_build_prompt_full_history_custom_limit():
+    messages = [
+        Message(role="user", content="hi"),
+        Message(role="assistant", content="ok"),
+        Message(role="user", content="read it"),
+        Message(role="tool", content="t" * 5000, tool_call_id="c9"),
+    ]
+    prompt, tool_mode = build_prompt(messages, has_session=False, tool_result_limit=100)
+    assert tool_mode
+    assert "[truncated: 4900 more characters]" in prompt
+
+
+# --- corrupted "tool_calls" key separator ---
+
+
+def test_repair_tool_calls_key_inserts_colon_and_bracket():
+    from danyapi.tools import _repair_tool_calls_key
+
+    assert _repair_tool_calls_key('{"tool_calls"> {"name": "a"}}') == '{"tool_calls": [ {"name": "a"}}'
+    # Value already starts with "[" — only the colon is re-inserted.
+    assert _repair_tool_calls_key('{"tool_calls"> [1, 2]}') == '{"tool_calls":  [1, 2]}'
+    # A valid separator is left untouched.
+    assert _repair_tool_calls_key('{"tool_calls": [{"name": "a"}]}') == '{"tool_calls": [{"name": "a"}]}'
+
+
+def test_parse_tool_calls_corrupted_separator():
+    # DeepSeek Pro sometimes emits "tool_calls"> instead of "tool_calls": [
+    text = 'Still reading.\n\n```json\n{\n  "tool_calls">\n    {\n      "name": "get_weather",\n      "arguments": {"city": "London"}\n    }\n  ]\n}\n```'
+    parsed = parse_tool_calls(text)
+    assert parsed is not None
+    calls, wrapper = parsed
+    assert [c.name for c in calls] == ["get_weather"]
+    assert calls[0].arguments == '{"city": "London"}'
+    assert "Still reading" in wrapper
+
+
+def test_parse_tool_calls_corrupted_separator_multiple():
+    text = '```json\n{\n  "tool_calls">\n    {"name": "a", "arguments": {"x": 1}},\n    {"name": "b", "arguments": {"y": 2}}\n  ]\n}\n```'
+    parsed = parse_tool_calls(text)
+    assert parsed is not None
+    calls, _ = parsed
+    assert [c.name for c in calls] == ["a", "b"]
+
+
+def test_parse_tool_calls_corrupted_separator_missing_closer():
+    # Both the corrupted separator and the closing bracket are dropped.
+    text = '{"tool_calls"> {"name": "a", "arguments": {"x": 1}}}'
+    parsed = parse_tool_calls(text)
+    assert parsed is not None
+    calls, _ = parsed
+    assert [c.name for c in calls] == ["a"]
+
+
+# --- tool_schema_map declared types (anyOf/oneOf/allOf) ---
+
+
+def test_tool_schema_map_anyof_integer_union():
+    assert tool_schema_map([READ_TOOL])["Read"]["line_offset"] == "integer"
+
+
+def test_tool_schema_map_array_property_hint():
+    assert tool_schema_map([TODO_TOOL])["TodoList"]["todos"] == "array"
+
+
+def test_tool_schema_map_array_string_union_prefers_array():
+    tool = {
+        "type": "function",
+        "function": {
+            "name": "f",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "a": {"anyOf": [{"type": "string"}, {"type": "array"}]},
+                },
+            },
+        },
+    }
+    assert tool_schema_map([tool])["f"]["a"] == "array"
+
+
+def test_tool_schema_map_nullable_string_prefers_string():
+    tool = {
+        "type": "function",
+        "function": {
+            "name": "f",
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "a": {"anyOf": [{"type": "string"}, {"type": "null"}]},
+                    "b": {"type": ["string", "null"]},
+                },
+            },
+        },
+    }
+    assert tool_schema_map([tool])["f"] == {"a": "string", "b": "string"}
+
+
+def test_tool_schema_map_property_without_type_skipped():
+    tool = {
+        "type": "function",
+        "function": {
+            "name": "f",
+            "parameters": {"type": "object", "properties": {"opts": {"description": "free form"}}},
+        },
+    }
+    assert "f" not in tool_schema_map([tool])
+
+
+# --- XML parameter coercion ---
+
+
+def test_coerce_scalar_array_object_hints():
+    assert _coerce_scalar("[1, 2]", "array") == [1, 2]
+    assert _coerce_scalar('{"a": 1}', "object") == {"a": 1}
+    # A failed JSON parse falls back to the raw string.
+    assert _coerce_scalar("plain text", "array") == "plain text"
+
+
+def test_coerce_json_container():
+    from danyapi.tools import _coerce_json_container
+
+    assert _coerce_json_container("[1, 2, 3]") == [1, 2, 3]
+    assert _coerce_json_container('{"a": 1}') == {"a": 1}
+    # Scalars and non-JSON stay strings.
+    assert _coerce_json_container("42") == "42"
+    assert _coerce_json_container("[ not json ]") == "[ not json ]"
+    assert _coerce_json_container("") == ""
+
+
+def test_coerce_untyped_literals():
+    from danyapi.tools import _coerce_untyped
+
+    assert _coerce_untyped("true") is True
+    assert _coerce_untyped("false") is False
+    assert _coerce_untyped("null") is None
+    assert _coerce_untyped("42") == 42
+    assert _coerce_untyped("3.5") == 3.5
+    assert _coerce_untyped("[1, 2]") == [1, 2]
+    assert _coerce_untyped("hello") == "hello"
+
+
+def test_xml_parameter_string_attrs_with_anyof_schema():
+    # DeepSeek emits non-string values annotated with string="false", and the
+    # client schema may declare the property only via anyOf (no top-level type).
+    text = (
+        "<tool_calls>\n"
+        '<invoke name="Read">\n'
+        '<parameter name="path" string="true">/home/u/proj/src/llm/mod.rs</parameter>\n'
+        '<parameter name="line_offset" string="false">370</parameter>\n'
+        '<parameter name="n_lines" string="false">40</parameter>\n'
+        "</invoke>\n"
+        "</tool_calls>"
+    )
+    parsed = parse_tool_calls(text, tool_schema_map([READ_TOOL]))
+    assert parsed is not None
+    calls, _ = parsed
+    args = json.loads(calls[0].arguments)
+    assert args["path"] == "/home/u/proj/src/llm/mod.rs"
+    assert args["line_offset"] == 370
+    assert args["n_lines"] == 40
+
+
+def test_xml_anyof_integer_coerced_from_schema_without_attrs():
+    text = '<tool_calls><invoke name="Read"><parameter name="path">a.rs</parameter><parameter name="line_offset">-100</parameter></invoke></tool_calls>'
+    parsed = parse_tool_calls(text, tool_schema_map([READ_TOOL]))
+    assert parsed is not None
+    calls, _ = parsed
+    args = json.loads(calls[0].arguments)
+    assert args["line_offset"] == -100
+
+
+def test_xml_string_attr_false_without_schema():
+    text = (
+        '<tool_calls><invoke name="f">'
+        '<parameter name="limit" string="false">42</parameter>'
+        '<parameter name="block" string="false">false</parameter>'
+        '<parameter name="note" string="true">42</parameter>'
+        "</invoke></tool_calls>"
+    )
+    parsed = parse_tool_calls(text)
+    assert parsed is not None
+    calls, _ = parsed
+    assert json.loads(calls[0].arguments) == {"limit": 42, "block": False, "note": "42"}
+
+
+def test_xml_empty_invoke_zero_arg_tool():
+    # EnterPlanMode (and similar zero-arg tools) are invoked with an empty
+    # body; before the fix the whole block stayed as plain text.
+    text = 'Let me call EnterPlanMode.\n\n<tool_calls><invoke name="EnterPlanMode"></invoke></tool_calls>'
+    parsed = parse_tool_calls(text)
+    assert parsed is not None
+    calls, wrapper = parsed
+    assert calls[0].name == "EnterPlanMode"
+    assert calls[0].arguments == "{}"
+    assert wrapper == "Let me call EnterPlanMode."
+
+
+def test_xml_array_param_json_string():
+    # DeepSeek emits nested arrays as pre-serialized JSON strings; the client
+    # schema (zod) rejects a string where an array is expected.
+    text = (
+        '<tool_calls><invoke name="TodoList">'
+        '<parameter name="todos">[{"title": "a", "status": "pending"}, {"title": "b", "status": "in_progress"}]</parameter>'
+        "</invoke></tool_calls>"
+    )
+    parsed = parse_tool_calls(text, tool_schema_map([TODO_TOOL]))
+    assert parsed is not None
+    calls, _ = parsed
+    args = json.loads(calls[0].arguments)
+    assert args["todos"][0] == {"title": "a", "status": "pending"}
+    assert args["todos"][1]["status"] == "in_progress"
+
+
+def test_xml_array_param_json_string_without_schema():
+    # No schema available, but the model marks the parameter string="false".
+    text = '<tool_calls><invoke name="TodoList"><parameter name="todos" string="false">[{"title": "a", "status": "pending"}]</parameter></invoke></tool_calls>'
+    parsed = parse_tool_calls(text)
+    assert parsed is not None
+    calls, _ = parsed
+    args = json.loads(calls[0].arguments)
+    assert args["todos"] == [{"title": "a", "status": "pending"}]
+
+
+def test_xml_array_param_plain_text_stays_string():
+    text = '<tool_calls><invoke name="TodoList"><parameter name="todos">[ -f /tmp/x ]</parameter></invoke></tool_calls>'
+    parsed = parse_tool_calls(text, tool_schema_map([TODO_TOOL]))
+    assert parsed is not None
+    calls, _ = parsed
+    args = json.loads(calls[0].arguments)
+    assert args["todos"] == "[ -f /tmp/x ]"
+
+
+def test_xml_bare_array_body():
+    text = '<tool_calls><invoke name="TodoList">[{"title": "a", "status": "pending"}]</invoke></tool_calls>'
+    parsed = parse_tool_calls(text, tool_schema_map([TODO_TOOL]))
+    assert parsed is not None
+    calls, _ = parsed
+    args = json.loads(calls[0].arguments)
+    assert args == [{"title": "a", "status": "pending"}]

--- a/tests/test_tools_api.py
+++ b/tests/test_tools_api.py
@@ -45,11 +45,59 @@ DS_XML_SSE = (
     "\n"
 )
 
+DS_JSON_SSE = (
+    "event: ready\n"
+    'data: {"request_message_id":1,"response_message_id":2,"model_type":"default"}\n'
+    "\n"
+    'data: {"v":{"response":{"message_id":2,"parent_id":1,"status":"WIP","fragments":['
+    + '{"id":2,"type":"RESPONSE","content":'
+    + json.dumps('{"answer": 42}')
+    + "}]}}}\n"
+    "\n"
+    'data: {"p":"response/status","o":"SET","v":"FINISHED"}\n'
+    "\n"
+)
+
+DS_BAD_JSON_SSE = (
+    "event: ready\n"
+    'data: {"request_message_id":1,"response_message_id":2,"model_type":"default"}\n'
+    "\n"
+    'data: {"v":{"response":{"message_id":2,"parent_id":1,"status":"WIP","fragments":['
+    + '{"id":2,"type":"RESPONSE","content":'
+    + json.dumps("not json at all")
+    + "}]}}}\n"
+    "\n"
+    'data: {"p":"response/status","o":"SET","v":"FINISHED"}\n'
+    "\n"
+)
+
 QWEN_TOOL_SSE = (
     'data: {"response.created":{"chat_id":"c1","parent_id":"p0","response_id":"r1","response_index":"0"}} \n'
     "\n"
     'data: {"choices": [{"delta": {"role": "assistant", "content": '
     + json.dumps(TOOL_JSON)
+    + ', "phase": "answer", "status": "typing"}}], "response_id": "r1"}\n'
+    "\n"
+    'data: {"choices": [{"delta": {"content": "", "role": "assistant", "status": "finished", "phase": "answer"}}], "response_id": "r1"}\n'
+    "\n"
+)
+
+QWEN_JSON_SSE = (
+    'data: {"response.created":{"chat_id":"c1","parent_id":"p0","response_id":"r1","response_index":"0"}} \n'
+    "\n"
+    'data: {"choices": [{"delta": {"role": "assistant", "content": '
+    + json.dumps('{"answer": 42}')
+    + ', "phase": "answer", "status": "typing"}}], "response_id": "r1"}\n'
+    "\n"
+    'data: {"choices": [{"delta": {"content": "", "role": "assistant", "status": "finished", "phase": "answer"}}], "response_id": "r1"}\n'
+    "\n"
+)
+
+QWEN_BAD_JSON_SSE = (
+    'data: {"response.created":{"chat_id":"c1","parent_id":"p0","response_id":"r1","response_index":"0"}} \n'
+    "\n"
+    'data: {"choices": [{"delta": {"role": "assistant", "content": '
+    + json.dumps("not json at all")
     + ', "phase": "answer", "status": "typing"}}], "response_id": "r1"}\n'
     "\n"
     'data: {"choices": [{"delta": {"content": "", "role": "assistant", "status": "finished", "phase": "answer"}}], "response_id": "r1"}\n'
@@ -214,3 +262,104 @@ async def test_qwen_stream_emits_tool_call_deltas():
     assert '"tool_calls"' in joined
     assert '"finish_reason": "tool_calls"' in joined
     assert joined.rstrip().endswith("data: [DONE]")
+
+
+JSON_ANSWER_SCHEMA = {"type": "object", "required": ["answer"], "properties": {"answer": {"type": "integer"}}}
+
+
+async def test_json_schema_valid_response_passes():
+    acct = FakeAccount([DS_JSON_SSE])
+    result = await openai_mod._collect_non_stream(**{**_deepseek_args(acct, tool_mode=False), "json_schema": JSON_ANSWER_SCHEMA})
+    choice = result["choices"][0]
+    assert choice["finish_reason"] == "stop"
+    assert choice["message"]["content"] == '{"answer": 42}'
+
+
+async def test_json_schema_invalid_json_raises():
+    acct = FakeAccount([DS_BAD_JSON_SSE])
+    with pytest.raises(openai_mod.HTTPException) as exc:
+        await openai_mod._collect_non_stream(**{**_deepseek_args(acct, tool_mode=False), "json_schema": JSON_ANSWER_SCHEMA})
+    assert exc.value.status_code == 400
+    assert "Invalid JSON response" in str(exc.value.detail)
+
+
+async def test_json_schema_mismatch_raises():
+    acct = FakeAccount([DS_JSON_SSE])
+    with pytest.raises(openai_mod.HTTPException) as exc:
+        await openai_mod._collect_non_stream(**{**_deepseek_args(acct, tool_mode=False), "json_schema": {"type": "object", "required": ["score"]}})
+    assert exc.value.status_code == 400
+    assert "does not match JSON schema" in str(exc.value.detail)
+
+
+async def test_json_schema_no_schema_no_validation():
+    acct = FakeAccount([DS_BAD_JSON_SSE])
+    result = await openai_mod._collect_non_stream(**{**_deepseek_args(acct, tool_mode=False), "json_schema": None})
+    assert result["choices"][0]["finish_reason"] == "stop"
+
+
+async def test_stream_json_schema_error_terminates_stream():
+    acct = FakeAccount([DS_BAD_JSON_SSE])
+    gen = openai_mod._stream_openai(**{**_deepseek_args(acct, tool_mode=False), "json_schema": JSON_ANSWER_SCHEMA})
+    lines = await collect_stream(gen)
+    joined = "".join(lines)
+    assert '"finish_reason": "error"' in joined
+    assert "Invalid JSON response" in joined
+    assert joined.rstrip().endswith("data: [DONE]")
+
+
+async def test_qwen_json_schema_valid_response_passes():
+    acct = FakeAccount([QWEN_JSON_SSE])
+    result = await qwen_api.collect_non_stream(**{**_qwen_args(acct, tool_mode=False), "json_schema": JSON_ANSWER_SCHEMA})
+    choice = result["choices"][0]
+    assert choice["finish_reason"] == "stop"
+    assert choice["message"]["content"] == '{"answer": 42}'
+
+
+async def test_qwen_json_schema_invalid_json_raises():
+    acct = FakeAccount([QWEN_BAD_JSON_SSE])
+    with pytest.raises(openai_mod.HTTPException) as exc:
+        await qwen_api.collect_non_stream(**{**_qwen_args(acct, tool_mode=False), "json_schema": JSON_ANSWER_SCHEMA})
+    assert exc.value.status_code == 400
+
+
+async def test_qwen_stream_json_schema_error_terminates_stream():
+    acct = FakeAccount([QWEN_BAD_JSON_SSE])
+    gen = qwen_api.stream_openai(**{**_qwen_args(acct, tool_mode=False), "json_schema": JSON_ANSWER_SCHEMA})
+    lines = await collect_stream(gen)
+    joined = "".join(lines)
+    assert '"finish_reason": "error"' in joined
+    assert "Invalid JSON response" in joined
+    assert joined.rstrip().endswith("data: [DONE]")
+
+
+def test_resolve_thinking_explicit_flag_wins():
+    req = openai_mod.ChatCompletionRequest(thinking=False, reasoning_effort="high")
+    assert openai_mod._resolve_thinking(req, default=True) is False
+    req = openai_mod.ChatCompletionRequest(thinking=True, reasoning_effort="none")
+    assert openai_mod._resolve_thinking(req, default=False) is True
+
+
+@pytest.mark.parametrize("effort", ["low", "medium", "high"])
+def test_resolve_thinking_effort_enables_thinking(effort):
+    req = openai_mod.ChatCompletionRequest(reasoning_effort=effort)
+    assert openai_mod._resolve_thinking(req, default=False) is True
+
+
+@pytest.mark.parametrize("effort", ["none", "off", "", "   "])
+def test_resolve_thinking_off_effort_falls_back_to_default(effort):
+    req = openai_mod.ChatCompletionRequest(reasoning_effort=effort)
+    assert openai_mod._resolve_thinking(req, default=False) is False
+    assert openai_mod._resolve_thinking(req, default=True) is True
+
+
+def test_resolve_thinking_effort_is_case_and_space_insensitive():
+    req = openai_mod.ChatCompletionRequest(reasoning_effort="  High ")
+    assert openai_mod._resolve_thinking(req, default=False) is True
+    req = openai_mod.ChatCompletionRequest(reasoning_effort="NONE")
+    assert openai_mod._resolve_thinking(req, default=False) is False
+
+
+def test_resolve_thinking_no_effort_uses_default():
+    req = openai_mod.ChatCompletionRequest()
+    assert openai_mod._resolve_thinking(req, default=False) is False
+    assert openai_mod._resolve_thinking(req, default=True) is True


### PR DESCRIPTION
## Problem

DanyAPI's OpenAI-compatible surface had four gaps that made it awkward to drive from standard OpenAI clients (e.g. Kimi Code) and fragile against long sessions or messy upstream output:

1. No `reasoning_effort` — clients that send `reasoning_effort` instead of a provider-specific `thinking` flag got no thinking path.
2. Long tool results (full file reads, large command output) were passed verbatim into the upstream prompt and could blow the context window.
3. The tool-call parser dropped calls when the model emitted a corrupted `tool_calls` key or XML `<parameter>` arguments with untyped non-string values; empty bodies were treated as "no call" instead of zero-argument calls.
4. `response_format: {"type": "json_schema", ...}` was accepted but never validated — schema mismatches surfaced only when the *client* tried to parse the reply.

## What changed

- **`reasoning_effort`** (`danyapi/api/openai.py`): new field on `ChatCompletionRequest`; `_resolve_thinking()` maps any non-off value to `thinking=True`. Explicit `thinking` still wins.
- **Tool-result truncation** (`danyapi/tools.py`, `danyapi/config.py`): `_truncate_tool_result()` caps each tool result at `DANYAPI_TOOL_RESULT_MAX_CHARS` (default 8000, `0` disables) before it enters the upstream prompt. Wired through `render_message` / `_render_history` / `_render_tool_tail`.
- **Tool-call parser hardening** (`danyapi/tools.py`): repairs a corrupted `tool_calls` key (missing colon/bracket), accepts list-valued JSON schema types, and coerces XML `<parameter>` arguments using declared types plus a `string="false"` hint for untyped values. Empty bodies now parse as `{}` (zero-argument call).
- **`json_schema` validation** (`danyapi/qwen/api.py`, `danyapi/api/openai.py`, `requirements.txt`): replies in JSON mode are parsed and validated against the supplied schema via the new `jsonschema` dependency. Invalid JSON or a schema mismatch raises HTTP 400; in streaming mode the stream terminates with an error chunk.

## Tests

+37 new cases across `tests/test_tools.py` and `tests/test_tools_api.py` covering each of the four areas (truncation limits, XML coercion edge cases, corrupted-key repair, json_schema valid/invalid/mismatch, streaming error termination, `reasoning_effort` mapping). Full suite: **694 passed, 10 skipped**.

## Verification

All four features were exercised against live DeepSeek traffic through the running server (non-stream chat, streaming, tool calls, `reasoning_effort: "high"` returning `reasoning_content`, `json_schema` reply validated, long tool result truncated and still answered correctly).